### PR TITLE
Set alpha value when applying gamma correct.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gamma-lut"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Mason Chang <mchang@mozilla.com>",
            "Dzmitry Malyshau <dmalyshau@mozilla.com>"]
 description = "Rust port of Skia gamma correcting tables"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,12 @@ pub enum LuminanceColorSpace {
 
 impl LuminanceColorSpace {
     pub fn new(gamma: f32) -> LuminanceColorSpace {
-        match gamma {
-            1.0 => LuminanceColorSpace::Linear,
-            0.0 => LuminanceColorSpace::Srgb,
-            _ => LuminanceColorSpace::Gamma(gamma),
+        if gamma == 1.0 {
+            LuminanceColorSpace::Linear
+        } else if gamma == 0.0 {
+            LuminanceColorSpace::Srgb
+        } else {
+            LuminanceColorSpace::Gamma(gamma)
         }
     }
 
@@ -331,7 +333,7 @@ impl GammaLut {
                 pixel[0] = table_g[luminance as usize];
                 pixel[1] = table_g[luminance as usize];
                 pixel[2] = table_g[luminance as usize];
-                // Don't touch alpha
+                pixel[3] = table_g[luminance as usize];
             }
         }
     }


### PR DESCRIPTION
This is necessary since we use pre-multiplied alpha for text runs now.

Required as part of https://github.com/servo/webrender/issues/1811.

Also fix a compiler warning about float pattern matches.
