### PR TITLE
add Color quantization function for normalizing table lookups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gamma-lut"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Mason Chang <mchang@mozilla.com>",
            "Dzmitry Malyshau <dmalyshau@mozilla.com>"]
 description = "Rust port of Skia gamma correcting tables"


### PR DESCRIPTION
Currently in WebRender we are using the color of a FontInstance at full precision as part of the key in the glyph cache, in allowance for preblending being baked into the rasterized result.

However, the preblending is only operating at 3 bits of precision, not 8. Skia accounts for this by quantizing the color used in its keys. We should be doing this in WebRender as well.

This adds some necessary utility functions to Color that will easily allow us to do this.