### PR TITLE
make fields of Color public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gamma-lut"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Mason Chang <mchang@mozilla.com>",
            "Dzmitry Malyshau <dmalyshau@mozilla.com>"]
 description = "Rust port of Skia gamma correcting tables"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@ pub const LUM_BITS: u8 = 3;
 
 #[derive(Copy, Clone)]
 pub struct Color {
-    r: u8,
-    g: u8,
-    b: u8,
-    a: u8,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
 }
 
 impl Color {


### PR DESCRIPTION
Oops, Need to make sure the color fields can actually be accessed otherwise all the quantization functions don't do anyone any good, since the result can't be used without...