### PR TITLE
add quantized_floor and quantized_ceil to Color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gamma-lut"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Mason Chang <mchang@mozilla.com>",
            "Dzmitry Malyshau <dmalyshau@mozilla.com>"]
 description = "Rust port of Skia gamma correcting tables"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,8 @@ fn compute_luminance(r: u8, g: u8, b: u8) -> u8 {
 
 // Skia uses 3 bits per channel for luminance.
 pub const LUM_BITS: u8 = 3;
+// Mask of the highest 3 bits.
+pub const LUM_MASK: u8 = ((1 << LUM_BITS) - 1) << (8 - LUM_BITS);
 
 #[derive(Copy, Clone)]
 pub struct Color {
@@ -128,6 +130,26 @@ impl Color {
             scale255(LUM_BITS, self.r >> (8 - LUM_BITS)),
             scale255(LUM_BITS, self.g >> (8 - LUM_BITS)),
             scale255(LUM_BITS, self.b >> (8 - LUM_BITS)),
+            self.a,
+        )
+    }
+
+    // Quantize to the smallest value that yields the same table index.
+    pub fn quantized_floor(&self) -> Color {
+        Color::new(
+            self.r & LUM_MASK,
+            self.g & LUM_MASK,
+            self.b & LUM_MASK,
+            self.a,
+        )
+    }
+
+    // Quantize to the largest value that yields the same table index.
+    pub fn quantized_ceil(&self) -> Color {
+        Color::new(
+            self.r | !LUM_MASK,
+            self.g | !LUM_MASK,
+            self.b | !LUM_MASK,
             self.a,
         )
     }


### PR DESCRIPTION
This will allow a slightly cleaner solution preserving light/dark mask determination while quantizing for macOS. While the normal quantize tries to make an average, these utility functions allow us to pick the smallest or lowest, which is useful for respecting the mask determination threshold in that specific case.